### PR TITLE
Fix missing json import in new.py

### DIFF
--- a/new.py
+++ b/new.py
@@ -1,5 +1,6 @@
 import requests
 import yaml
+import json
 
 def load_operations(file_path):
     with open(file_path, 'r') as file:


### PR DESCRIPTION
## Summary
- fix missing json import for CyberArk script

## Testing
- `python3 -m py_compile new.py`


------
https://chatgpt.com/codex/tasks/task_e_68438a9d4110832f954c75e51e46ee51